### PR TITLE
Link SEO & accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ window.cookieConsent = {
         title: 'We use cookies',
         description: 'This website uses cookies in order to enhance your overall user experience.',
         cookiePolicy: 'Choose from the options below to manage your cookie preferences. :link(Click here) to read our cookie/privacy policy.',
+        ariaLabel: 'View our cookie policy',
         buttons: {
             onlyEssentials: 'Only essentials',
             acceptAll: 'Accept all',

--- a/src/CookieConsent.vue
+++ b/src/CookieConsent.vue
@@ -94,7 +94,7 @@ const resetState = () => (customiseOpen.value = false)
 
 const cookieText = props.data?.text.cookiePolicy.replace(
   /:link\((.*?)\)/,
-  `<a id="cookieconsent__link" href="${props.data?.cookiePolicy}" target="_blank">$1</a>`
+  `<a id="cookieconsent__link" href="${props.data?.cookiePolicy}" target="_blank" aria-label="${props.data?.text.ariaLabel}">$1</a>`
 )
 
 const applyGtagPreferences = (denied = false) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ const data: cookieConsent = deepMerge(
       description: 'This website uses cookies in order to enhance your overall user experience.',
       cookiePolicy:
         'Choose from the options below to manage your cookie preferences. :link(Click here) to read our cookie/privacy policy.',
+      ariaLabel: 'View our cookie policy',
       buttons: {
         onlyEssentials: 'Only essentials',
         acceptAll: 'Accept all',

--- a/src/types/cookieConsent.d.ts
+++ b/src/types/cookieConsent.d.ts
@@ -7,6 +7,7 @@ interface cookieConsent {
     title: string
     description: string
     cookiePolicy: string
+    ariaLabel: string
     buttons: {
       onlyEssentials: string
       acceptAll: string


### PR DESCRIPTION
When testing a recent project's performance via PageSpeed & Lighthouse, Google automatically flags link text such as "Click here" to be detrimental to SEO best practices as shown below.

![cookie-consent-link-accessibility-example](https://github.com/user-attachments/assets/ac4c0457-3c42-4393-884a-180c320627e9)

I have made the simple addition of an optional `aria-label` for the Cookie Consent modal link to try and accommodate this better on page insights.

I have also updated the README accordingly to include it in the full configuration example.